### PR TITLE
coturn: improve reproducibility (Ubuntu build host fix)

### DIFF
--- a/net/coturn/Makefile
+++ b/net/coturn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coturn
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coturn/coturn/tar.gz/$(PKG_VERSION)?
@@ -129,6 +129,7 @@ CONFIGURE_ARGS+= \
 	--turndbdir=/etc/turnserver
 
 CONFIGURE_VARS+= \
+	ARCHIVERCMD="$(TARGET_AR) -r" \
 	LIBEV_OK=1 \
 	TURN_NO_PROMETHEUS=1 \
 	TURN_NO_SCTP=1 \

--- a/net/coturn/Makefile
+++ b/net/coturn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coturn
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coturn/coturn/tar.gz/$(PKG_VERSION)?
@@ -129,6 +129,7 @@ CONFIGURE_ARGS+= \
 	--turndbdir=/etc/turnserver
 
 CONFIGURE_VARS+= \
+	LIBEV_OK=1 \
 	TURN_NO_PROMETHEUS=1 \
 	TURN_NO_SCTP=1 \
 	TURN_NO_SYSTEMD=1 \


### PR DESCRIPTION
coturn package is reproducible unless the build OS is Ubuntu

coturn configure script detects Ubuntu build host([1]) and changes
compilation flags so produced OpenWrt binaries are different on
Ubuntu and any other build OS (e.g. Debian). It might be necessary
for native build but this check is not valid for cross-compiling.

This patch set LIBEV_OK=1 to generate the same binaries on Ubuntu
and other build OS

Refs:
[1] https://github.com/coturn/coturn/blob/upstream/4.5.2/configure#L426-L435

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Please double check that your commits:
- all start with "<package name>: "
- all contain signed-off-by
- are linked to your github account (you see your logo in front of them)

Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Maintainer: me / @<github-user>
Compile tested: (put here arch, model, OpenWRT/LEDE version)
Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)

Description:
